### PR TITLE
Revert librestapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
 	"webpack": "^1.13.1"
     },
     "dependencies": {
-	"librestapi": "^0.3.4"
+	"librestapi": "=0.2.4"
     }
 }

--- a/src/app/knotis.js
+++ b/src/app/knotis.js
@@ -5,7 +5,7 @@ import {
     Resource
 } from 'librestapi';
 
-import Promise from 'es6-promise';
+import Promise from 'promise';
 import extend from 'node.extend';
 
 class Knotis extends RestApi {


### PR DESCRIPTION
The new version on librestapi is pulling in some weird dependencies that I don't understand. reverting to version 0.2.4 for now.
