### PR TITLE
Zero SignIn Endpoint & Bypass Current Coordinates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knotisapi",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Javascript library for accessing the Knotis REST API.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/app/knotis.js
+++ b/src/app/knotis.js
@@ -25,7 +25,16 @@ class Knotis extends RestApi {
             }
         );
 
+        this.OneUseToken = new Resource(
+            this, {
+                path: 'auth/onetimeusetoken',
+                name: 'one_use_token',
+                auth_required: false
+            }
+        );
+
         this.User.ImageHistory = this.Image;
+        this.User.OneUseToken = this.OneUseToken;
 
         this.NewUser = new Resource(
             this, {
@@ -418,6 +427,17 @@ class Knotis extends RestApi {
 
             data.lat = gps.latitude;
             data.lon = gps.longitude;
+        }
+
+        if (
+            'undefined' !== typeof data &&
+            'undefined' !== typeof data.loc_bypass &&
+            data.loc_bypass &&
+            data.loc_bypass.lat &&
+            data.loc_bypass.lon
+        ) {
+            data.lat = data.loc_bypass.lat;
+            data.lon = data.loc_bypass.lon;
         }
 
         if(!data){


### PR DESCRIPTION
- Zero SignIn Endpoint
- Currently, only the phone's current gps coordinates can be used.
- Override the current coordinates by adding loc_bypass to the params.
- One request use only.