### PR TITLE
Update Library Initialization Docs

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -12,10 +12,10 @@ Initializing the library is easy. It only requires passing in a simple configura
     :linenos:
 
     let options = {
-        api_key: '<your api key>',  //DO NOT SAVE IN YOUR REPOSITORY
-        api_secret: '<your api secret>',  //DO NOT SAVE IN YOUR REPOSITORY
-        api_root: 'https://knotis.com/api',
-        auth_uri: 'https://knotis.com/oauth2/token'
+        api_key: '<your api key>',  // DO NOT SAVE IN YOUR REPOSITORY
+        api_secret: '<your api secret>',  // DO NOT SAVE IN YOUR REPOSITORY
+        api_root: 'https://knotis.com/api',  // NO TRAILING SLASH!
+        auth_uri: 'https://knotis.com/oauth2/token/'  // TRAILING SLASH REQUIRED HERE!!!
     }
 
 Once you have your configuration object generated initilizing the api is as simple as:


### PR DESCRIPTION
* I updated the docs to reflect that a trailing slash is required on the auth_uri but it needs to be ommited on the api_root. This should be fixed in the future but I am updating docs now to hopefully avoid some confusion in the mean time.