### PR TITLE
Fix Promise Not Returned from Password Grant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knotisapi",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Javascript library for accessing the Knotis REST API.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/app/knotis.js
+++ b/src/app/knotis.js
@@ -377,7 +377,7 @@ class Knotis extends RestApi {
                 credentials
             );
         });
-    }
+    };
     
 
     passwordGrant(
@@ -392,7 +392,7 @@ class Knotis extends RestApi {
                 password: password
             };
 
-            this.authenticate(
+            return this.authenticate(
                 credentials
             );
         });

--- a/tests/unit/knotis.js
+++ b/tests/unit/knotis.js
@@ -8,10 +8,35 @@ define(function (require) {
 
     registerSuite({
         name: 'knotis',
-        test_isknotisdefined: function () {
+        test_isKnotisDefined: function () {
             assert.isDefined(Knotis);
 
         },
+	test_isPasswordGrantDefined: function () {
+	    var client = new Knotis();
+	    assert.isDefined(client.passwordGrant)
+
+	},
+	test_isRefreshTokenDefined: function () {
+	    var client = new Knotis();
+	    assert.isDefined(client.passwordGrant)
+
+	},
+	test_isPromiseReturnedFromPasswordGrant: function () {
+	    var client = new Knotis();
+	    var promise = client.passwordGrant();
+
+	    assert.isDefined(promise.then);
+	    
+	},
+	test_isPromiseReturnedFromRefreshToken: function () {
+	    var client = new Knotis();
+	    var promise = client.refreshToken();
+
+	    assert.isDefined(promise.then);
+	    
+	}
+	
     });
 
 });


### PR DESCRIPTION
* I accidentally broke the passwordGrant method when I refactored the auth code that both passwordGrant and refreshToken use. I forgot to return the promise from the passwordGrant method.
* I added unit tests to verify that passwordGrant and refreshToken both returh promises and to make sure both methods are defined.
* Added a missing semicolon in knotis.js.
* Incremented patch revision to 1.8.1.