### PR TITLE
Remove Redundant Promise from Authentication Methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knotisapi",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Javascript library for accessing the Knotis REST API.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/app/knotis.js
+++ b/src/app/knotis.js
@@ -313,7 +313,9 @@ class Knotis extends RestApi {
         );
     };
 
-    authenticate(credentials) {
+    authenticate(
+	credentials
+    ) {
         let method = 'POST';
         let uri = this.options.auth_uri;
 
@@ -331,21 +333,20 @@ class Knotis extends RestApi {
         ).then((response) => {
             if (200 !== response.status_code) {
                 //Error Case
-                reject(response);
-                return;
+                return response;
             }
 
             this.setCredentials(response.data);
 
             let responseData = response.data;
 
-            this.User.retrieve(
+            return this.User.retrieve(
                 null
             ).then((response) => {
                 if (200 !== response.status_code) {
                     // error case
-                    reject(response);
-                    return;
+                    return response;
+
                 }
 
                 this.setCredentials({
@@ -355,28 +356,28 @@ class Knotis extends RestApi {
 
                 response.data = extend(responseData, response.data);
 
-                resolve(response);
-                return;
+                return response;
 
             });
+
         });
+
     };
 
     refreshToken(
 	refreshToken
     ) {
-        return new Promise((resolve, reject) => {
-            var credentials = {
-                grant_type: 'refresh_token',
-                client_id: this.options.api_key,
-		client_secret: this.options.api_secret,
-		refresh_token: refreshToken
-            };
+        var credentials = {
+            grant_type: 'refresh_token',
+            client_id: this.options.api_key,
+	    client_secret: this.options.api_secret,
+	    refresh_token: refreshToken
+        };
 
-            return this.authenticate(
-                credentials
-            );
-        });
+        return this.authenticate(
+            credentials
+        );
+
     };
     
 
@@ -384,19 +385,19 @@ class Knotis extends RestApi {
         username,
         password
     ) {
-        return new Promise((resolve, reject) => {
-            var credentials = {
-                grant_type: 'password',
-                client_id: this.options.api_key,
-                username: username,
-                password: password
-            };
+        var credentials = {
+            grant_type: 'password',
+            client_id: this.options.api_key,
+            username: username,
+            password: password
+        };
 
-            return this.authenticate(
-                credentials
-            );
-        });
+        return this.authenticate(
+            credentials
+        );
+	
     }
 }
+
 
 export default Knotis;


### PR DESCRIPTION
* I left a redundant promise in the code when I refactored the authentication methods. This promise never resolved therefore the promise hung forever. I removed this promise and not only the one returned from the authenticate method is returned.
* Incremented patch version to 1.8.2.